### PR TITLE
added ability to replace %%DBUP_*%% keyword in .ini configuration file to an environment variable which its key is matched

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ change the database config in `.dbup/properties.ini`.
 
 see also http://www.php.net/manual/en/pdo.construct.php
 
+You can also assign environment variables to your database configuration file. Dbup reads `DBUP_` prefixed environment variables if the names are placed in .ini file with surrounded '%%'. For example, `user` parameter of the following ini will be replaced to a value of the environment variable `DBUP_USERNAME` if it is defined.
+
+    [pdo]
+    user = "%%DBUP_USERNAME%%"
+
 Naming
 ------
 

--- a/src/Dbup/Application.php
+++ b/src/Dbup/Application.php
@@ -67,9 +67,20 @@ EOL;
         $this->pdo = new PdoDatabase($dsn, $user, $password, $driverOptions);
     }
 
-    public function setConfigFromIni($ini)
+    public function parseIniFile($path)
     {
-        $parse = parse_ini_file($ini, true);
+        $ini = file_get_contents($path);
+        $replaced = preg_replace_callback('/%%(DBUP_[^%]+)%%/', function ($matches) {
+            list($whole, $key) = $matches;
+            return isset($_SERVER[$key]) ? $_SERVER[$key] : $whole;
+        }, $ini);
+
+        return parse_ini_string($replaced, true);
+    }
+
+    public function setConfigFromIni($path)
+    {
+        $parse = $this->parseIniFile($path);
         if (!isset($parse['pdo'])) {
             throw new RuntimeException('cannot find [pdo] section in your properties.ini');
         }

--- a/tests/Dbup/.dbup/properties.ini.replace
+++ b/tests/Dbup/.dbup/properties.ini.replace
@@ -1,0 +1,4 @@
+[pdo]
+dsn = "%%DBUP_TEST_DBMS%%:dbname=%%DBUP_TEST_USER%%_%%DBUP_TEST_HOST%%_%%DBUP_TEST_NOT_REPLACED%%;host=%%DBUP_TEST_HOST%%"
+user = "%DBUP_TEST_USER%"
+password = "%%OTHER_PREFIX_DBUP_TEST_PASSWORD%%"

--- a/tests/Dbup/ApplicationTest.php
+++ b/tests/Dbup/ApplicationTest.php
@@ -31,6 +31,21 @@ Class ApplicationTest extends \PHPUnit_Framework_TestCase
         assertThat($this->app->getIni(), is('./.dbup/properties.ini'));
     }
 
+    public function testParseIniFileReplaceVariables()
+    {
+        $_SERVER['DBUP_TEST_DBMS'] = 'replaced_dbms';
+        $_SERVER['DBUP_TEST_USER'] = 'replaced_user';
+        $_SERVER['DBUP_TEST_HOST'] = 'replaced_host';
+        $_SERVER['OTHER_PREFIX_DBUP_TEST_PASSWORD'] = 'replaced_password';
+
+        $ini = __DIR__ . '/.dbup/properties.ini.replace';
+        $parsed = $this->app->parseIniFile($ini)['pdo'];
+
+        assertThat($parsed['dsn'], is('replaced_dbms:dbname=replaced_user_replaced_host_%%DBUP_TEST_NOT_REPLACED%%;host=replaced_host'));
+        assertThat($parsed['user'], is('%DBUP_TEST_USER%'));
+        assertThat($parsed['password'], is('%%OTHER_PREFIX_DBUP_TEST_PASSWORD%%'));
+    }
+
     public function testSetConfigFromIni()
     {
         $ini = __DIR__ . '/.dbup/properties.ini';


### PR DESCRIPTION
It might be useful some environments like Heroku.

The referenced implementation is [Phinx's one](http://docs.phinx.org/en/latest/configuration.html#external-variables) but my implementation does not have any code from Phinx.
